### PR TITLE
capx: upgrade-workflow memory + PCP-6871 decision ledgers (no code)

### DIFF
--- a/.claude/memory/capi-upgrade/README.md
+++ b/.claude/memory/capi-upgrade/README.md
@@ -1,0 +1,59 @@
+# CAPI Provider Upgrade — how this works (plain-language)
+
+Repo- & version-agnostic tooling for the periodic CAPI upgrade of this fork. All Claude content is
+under `.claude/`: `skills/` = shared logic (synced across forks), `memory/capi-upgrade/` = this
+fork's data + audit trail (per-repo, never synced).
+
+## The one-liner
+> Branch from the upstream release **tag**, replay the fork's spectro commits (from the integration
+> branch) onto it, classify each **PICK / SKIP / REGENERATE / NEEDS-DECISION**, and stop short of
+> anything unsafe — so you approve a plan before any code changes.
+
+## Layout
+```
+.claude/
+├── skills/                                  [SHARED, synced]
+│   ├── capi-provider-upgrade/               reconcile skill + engine
+│   │   ├── SKILL.md                  playbook
+│   │   ├── capi-commit-reconcile.sh         engine (plan | execute)
+│   │   ├── TEMPLATE-upgrade-record.md
+│   │   └── test/fixture-harness.sh          self-contained algorithm test (run on any engine change)
+│   ├── capi-validate.md                     validation gates (conversion fuzz, CRD diff, in-place upgrade)
+│   ├── capi-palette-integrate.md            Palette monorepo wiring
+│   └── capi-maas-release.md                 MAAS maintainer variant (spectro-owned; no reconcile)
+└── memory/capi-upgrade/                     [PER-REPO, committed]
+    ├── capi-upgrade.conf                    UPSTREAM_URL/PROVIDER/SPECTRO_SRC + classifier inputs
+    ├── capi-upgrade.md                      the ledger
+    ├── skip-commits.txt                     explicit human skip decisions
+    ├── known-commits.tsv                    (optional) authoritative SHA→category map
+    └── upgrades/                            generated records + summary.json
+```
+
+## How it runs
+```
+bash .claude/skills/capi-provider-upgrade/capi-commit-reconcile.sh --mode plan   [--target vX.Y.Z] [--skip-noise]
+bash .claude/skills/capi-provider-upgrade/capi-commit-reconcile.sh --mode execute [--target vX.Y.Z]
+```
+- **plan** = read-only (throwaway worktree) → writes `upgrades/<ts>-PLAN-*.md` + `summary.json`.
+- **execute** = creates the one branch `spectro-v<target>-master`, lands decisions, re-emits the record.
+- Target defaults to the latest upstream tag. Versions/contract/n-3/axis are **discovered** from
+  `go.mod` + `metadata.yaml` — nothing is hardcoded.
+
+## Decisions
+`PICK` (applies cleanly) · `SKIP` (already in target / skip-listed / --skip-noise) · `REGENERATE`
+(generated artifact — re-made via `make`, not cherry-picked) · `NEEDS-DECISION` (diverged/unknown/
+unsafe conflict → human). The branch is **INCOMPLETE** (not mergeable) while any NEEDS-DECISION or
+regen/verify remains.
+
+## Safety
+plan mutates nothing; execute only ever creates/commits `spectro-v<target>-master` — never deletes/
+force-updates branches, never `git clean`, never pushes, never touches `master`; aborts on
+uncommitted tracked changes.
+
+## Verify the engine
+`bash .claude/skills/capi-provider-upgrade/test/fixture-harness.sh <engine>` — 10 assertions incl.
+the no-silent-drop guard. Keep it green on any engine change.
+
+## Hand-offs
+Validation → `capi-validate`. Palette wiring → `capi-palette-integrate`. MAAS → `capi-maas-release`.
+PR gates / review / Luma fan-out → the pipeline layer.

--- a/.claude/memory/capi-upgrade/capi-1.12-parity.md
+++ b/.claude/memory/capi-upgrade/capi-1.12-parity.md
@@ -1,0 +1,77 @@
+# CAPI v1.12.0 Subnet/Dual-Stack Parity — Drift-Diff (spectro fork → upstream native)
+
+**Summary: 0 GAPs, 1 BEHAVIORAL-DIFF.** Dropping the spectro custom subnet commits in favor of
+upstream v1.12.0's native `cloud/services/compute/subnets/` package is a **near-total functional
+upgrade** — every capability the spectro `SubnetworkSpec()` path provided is COVERED (and exceeded)
+by upstream `SubnetSpecs()` + the `subnets` reconciler. The only behavioral difference is the
+**subnet-creation gating condition** (spectro gated on `!network.AutoCreateSubnetworks`; upstream
+always reconciles subnets). No functionality is lost; review the one BEHAVIORAL-DIFF.
+
+## Key structural finding
+
+The spectro commits added a SECOND, parallel subnet path inside the `networks` package
+(`ClusterScope.SubnetworkSpec()` / `ManagedClusterScope.SubnetworkSpec()` +
+`networks.createOrGetSubNetwork`). Meanwhile the fork ALSO already carries upstream's richer
+`SubnetSpecs()` method and the full upstream `SubnetSpec` API type (commits 615e368e and 2e9689fc
+actually modify the *upstream-style* `SubnetSpecs()` / `SubnetSpec`, not the spectro custom path).
+
+- Spectro custom path: `origin/spectro-release-4.9:cloud/services/compute/networks/reconcile.go:48-55, 184-208` and `cloud/scope/cluster.go:231`, `cloud/scope/managedcluster.go:215`.
+- Upstream native path (v1.12.0): `cloud/services/compute/subnets/{reconcile,service}.go`, `cloud/scope/cluster.go:266 SubnetSpecs()`, `cloud/scope/managedcluster.go SubnetSpecs()`.
+- The fork's `api/v1beta1/types.go SubnetSpec` is **already byte-identical** to `v1.12.0:api/v1beta1/types.go SubnetSpec` (Description, SecondaryCidrBlocks, PrivateGoogleAccess, EnableFlowLogs, Purpose, StackType all present). So the API surface is unchanged by the upgrade.
+
+Spectro's `SubnetworkSpec()` only ever populated **5 fields** (Name, Region, IpCidrRange, Network,
+EnableFlowLogs). Upstream's `SubnetSpecs()` populates **11 fields** (adds PrivateIpGoogleAccess,
+SecondaryIpRanges, Description, Purpose, Role, StackType). Upstream is a strict superset.
+
+## Capability matrix
+
+| Capability | Spectro (commit) | Upstream v1.12.0 | Verdict | Notes/risk |
+|---|---|---|---|---|
+| Custom subnet creation, self-managed | `SubnetworkSpec()` + `createOrGetSubNetwork` (01e06d72) wired in `networks` pkg | `subnets.New(clusterScope)` reconciler, wired in `controllers/gcpcluster_controller.go:205` | COVERED | Upstream uses a dedicated reconciler; create-or-get semantics equivalent. |
+| Custom subnet creation, managed (GKE) | `ManagedClusterScope.SubnetworkSpec()` (d8e22c72) | `subnets.New(clusterScope)` wired in `exp/controllers/gcpmanagedcluster_controller.go:200` | COVERED | Same `subnets` pkg reused for managed; reconcile + delete both wired (200/252). |
+| Subnet delete | spectro `networks.Delete` loop (01e06d72) | `subnets.Service.Delete` (`subnets/reconcile.go:43`), wired at gcpcluster_controller.go:236 / gcpmanagedcluster_controller.go:252 | COVERED | Upstream is SAFER: skips delete if subnet not CAPG-created (description check) and skips on Shared VPC. Spectro deleted unconditionally. |
+| Idempotent create-or-get | `createOrGetSubNetwork` (01e06d72) | `createOrGetSubnets` (`subnets/reconcile.go:81`) | COVERED | Identical Get→Insert→Get pattern. Neither updates/patches an existing subnet (no StackType/flowlogs reconcile-on-change in either). |
+| `EnableFlowLogs` field | set from `*subnet.EnableFlowLogs` (01e06d72) | `EnableFlowLogs: ptr.Deref(subnetwork.EnableFlowLogs, false)` (cluster.go:266 / managedcluster.go) | COVERED | Same field, same effective default (false when nil). |
+| `EnableFlowLogs` nil-check (panic guard) | `if subnet.EnableFlowLogs != nil` (8a9fbde4) | `ptr.Deref(..., false)` | COVERED | Upstream's `ptr.Deref` is the safer equivalent of the spectro nil-guard; no panic risk. |
+| `StackType` / dual-stack on subnet | `StackType: subnetwork.StackType` in `SubnetSpecs()` (615e368e) | `StackType: subnetwork.StackType` in `SubnetSpecs()` (cluster.go:266 / managedcluster.go) | COVERED | Identical line; this commit already targeted the upstream-style method, so it merges cleanly / is already present upstream. |
+| `StackType` API field + dual-stack enum/default | `SubnetSpec.StackType` enum IPV4_ONLY/IPV4_IPV6/IPV6_ONLY, default IPV4_ONLY (2e9689fc) | identical in `v1.12.0:api/v1beta1/types.go` | COVERED | API type byte-identical to fork; CRDs already carry the enum. No change. |
+| `k8scloud.Option` variadic on subnet iface | added options to Get/Insert/Delete (5dff97d6) | `subnets/service.go subnetsInterface` already has `options ...k8scloud.Option` | COVERED | Upstream interface already matches; spectro fix becomes obsolete (was a compile fix against the spectro custom iface, which is deleted). |
+| Secondary IP ranges | **NOT present** in spectro `SubnetworkSpec()` | `SecondaryIpRanges` built from `SecondaryCidrBlocks` (cluster.go:266) | COVERED (upstream ADDS) | Net gain, not a loss. |
+| Purpose / PrivateGoogleAccess / Description / Role | **NOT present** in spectro `SubnetworkSpec()` | all set in upstream `SubnetSpecs()` | COVERED (upstream ADDS) | Net gain, not a loss. |
+| Shared-VPC subnet handling | none in spectro path | `IsSharedVpc()` branches in `subnets/service.go New` + reconcile/delete | COVERED (upstream ADDS) | Net gain. |
+| Subnet creation gating | spectro only creates subnets when `!network.AutoCreateSubnetworks` (custom-mode VPC) — `networks/reconcile.go:48` | upstream `subnets.Reconcile` runs unconditionally for every entry in `Spec.Network.Subnets` | **BEHAVIORAL-DIFF** | See below. Low risk in practice but the only true behavior change. |
+
+## ⚠️ Functionality at risk (review before release)
+
+### BEHAVIORAL-DIFF 1 — Subnet-creation gating condition (the only behavior change)
+
+- **Spectro** (`origin/spectro-release-4.9:cloud/services/compute/networks/reconcile.go:48-55`):
+  subnets are created **only if** `!network.AutoCreateSubnetworks` (i.e. only when the VPC is in
+  custom subnet mode). In auto-subnet-mode VPCs, `Spec.Network.Subnets` entries are silently ignored.
+- **Upstream v1.12.0** (`cloud/services/compute/subnets/reconcile.go:81 createOrGetSubnets`):
+  the `subnets` reconciler iterates **every** entry in `Spec.Network.Subnets` and create-or-gets it,
+  with **no `AutoCreateSubnetworks` guard**.
+- **Effect of adopting upstream:** if a user defined `Spec.Network.Subnets` on an
+  auto-mode VPC, upstream will now attempt to create those subnets where spectro skipped them.
+  This is almost certainly the *correct* behavior (and matches CAPI intent), and create-or-get is
+  idempotent against an existing auto-created subnet, but it is a genuine behavioral change worth a
+  human nod — especially for any existing clusters that relied on the spectro skip.
+- **Risk: LOW.** No data loss; worst case is an extra subnet create attempt on auto-mode VPCs.
+
+### Non-issues confirmed (not gaps)
+
+- **EnableFlowLogs nil panic (8a9fbde4):** upstream uses `ptr.Deref(subnetwork.EnableFlowLogs, false)`
+  — no panic risk; the spectro nil-guard is redundant under upstream.
+- **k8scloud.Option fix (5dff97d6):** was a compile fix for the spectro custom `subnetworksInterface`
+  inside the `networks` pkg, which upstream deletes entirely (`networks` pkg no longer touches
+  subnets in v1.12.0). The upstream `subnets.subnetsInterface` already declares the variadic options.
+- **No idempotent UPDATE in either implementation:** neither spectro nor upstream patches an existing
+  subnet's StackType/EnableFlowLogs after creation. Changing those fields on an existing cluster is a
+  no-op in BOTH — so adopting upstream introduces no regression here.
+
+## Bottom line
+
+Adopting upstream v1.12.0's native subnet/dual-stack implementation **loses no functionality** and
+gains several capabilities (secondary ranges, Purpose, PrivateGoogleAccess, Description, Role,
+Shared-VPC awareness, safer delete). The single thing to flag to a human is the dropped
+`!network.AutoCreateSubnetworks` gate (BEHAVIORAL-DIFF 1).

--- a/.claude/memory/capi-upgrade/capi-upgrade.conf
+++ b/.claude/memory/capi-upgrade/capi-upgrade.conf
@@ -1,0 +1,25 @@
+# Per-repo config for capi-commit-reconcile.sh / capi-provider-upgrade skill.
+# Copy this file (edited) into each provider fork so the same skill works everywhere.
+UPSTREAM_URL=https://github.com/kubernetes-sigs/cluster-api-provider-gcp.git
+PROVIDER=capg
+# Cherry-pick SOURCE = canonical spectro integration branch (NOT a release snapshot).
+SPECTRO_SRC=origin/spectro-master
+OLD_BRANCH_GLOB=origin/spectro-release-*   # fallback only, if spectro-master is missing
+# BASE defaults to upstream/main; TARGET defaults to highest upstream vX.Y.Z tag (override with --target)
+#
+# Skip noise (chore/dependabot/package bumps/CVE) — enabled with --skip-noise. Tune the regex:
+SKIP_PATTERNS=^chore|bump|dependabot|vulns?|CVE|go version|golang|builder image|update go|merge pull request
+# For one-off explicit skips, list SHAs in .claude/memory/capi-upgrade/skip-commits.txt (always honored).
+
+# --- per-repo classifier data (GCP-specific; kept OUT of the shared engine) ---
+GENERATED_PATHS=config/|spectro/base|spectro/global|zz_generated
+F4_HOTSPOTS=cloud/services/compute/networks|cloud/services/compute/subnets|cloud/scope
+MANDATORY_PATTERNS=Added Spectro Manifests|exclusive webhook|Spectro CICD|self hosted runner|RBAC|ServiceAccount
+# --- integration/validation tail (Spec Patch) ---
+CLOUD=gcp
+CBT_FEATURE=lifecycle   # ally/tests/cbt go-test suite (NOT make cbt-<cloud>); select per cloud
+VENDORCRD=config/vendorcrd/gcp     # confirm exact config/vendorcrd/<dir>
+BUILD_VARS_ENABLED=1
+BUILD_VARS_MAKEFILE=Makefile
+BUILD_VARS_TAG_KEY=TAG
+BUILD_VARS_GO_KEY=BUILDER_GOLANG_VERSION

--- a/.claude/memory/capi-upgrade/known-commits.tsv
+++ b/.claude/memory/capi-upgrade/known-commits.tsv
@@ -1,0 +1,46 @@
+# CAPG known-commits map — SHA  CAT  DECISION-HINT  note   (authoritative; derived from capi-upgrade.md)
+# Mandatory palette infra (NOT skip-listed -> PICK)
+49630da7  REGEN  SKIP        Spectro manifests -> vendorcrd-sync regenerates (Patch F; NOT cherry-picked)
+3efd0cd7  M   PICK           Exclusive webhook + reconcilers (:9443 split)
+e97ddf43  M   PICK-RESOLVE   Spectro CICD integration — force-pick of conflicting mandatory (PR #282)
+eb9fc94c  M   PICK-RESOLVE   Self-hosted runner changes — force-pick of conflicting mandatory (PR #282)
+ebb77a32  REGEN  SKIP        reviewer-applied: RBAC/ServiceAccount lands ONLY in spectro/base + spectro/generated/core-base.yaml (generated overlay) -> vendorcrd-sync regenerates it (Patch F), NOT a cherry-pick. Target already carries ServiceAccount manager. POST-CONDITION: vendorcrd-sync verify --provider gcp must show capg-manager SA + RBAC.
+# Fork-only features to replay (NOT skip-listed -> PICK)
+0c6fb0e0  F2  PICK-RESOLVE   Route-delete fix — force-pick of conflicting F2 (PR #282)
+38428b73  F2  PICK-RESOLVE   PCP-268 GCPMachineTemplate ref fix — force-pick of conflicting F2 (PR #282)
+49615abe  F2  PICK           PCP-1277 remove Ready event
+b5f20633  F2  PICK           Create backport.yaml — reviewer-cleared, human PICK (PR #282 Gate 1)
+# Deviated (F4 — force-picked with reviewer §3 selective-re-apply guidance)
+e41bf6ae  F4  PICK-RESOLVE   Instance Size support — selective re-apply per reviewer §3 (PR #282)
+# Version/CVE/go bumps (also in skip-commits.txt -> SKIP; category here for record accuracy)
+d60388ac  M*  SKIP           controller-runtime bump — superseded by target
+5de82ade  M*  SKIP           CVE fixes — re-scan on target
+ce141d51  M*  SKIP           go vuln fixes — superseded
+3a44b400  M*  SKIP           go/pkg vuln updates — superseded
+beb5582e  M*  SKIP           Go/builder bump — superseded
+5b7e0a5c  M*  SKIP           go version bump — superseded
+21359136  M*  SKIP           go version bump (release yaml) — superseded
+da80f8c6  M*  SKIP           Go 1.23.8 bump — superseded
+ef3e587d  M*  SKIP           dependabot actions/checkout — superseded
+b30a9407  M*  SKIP           dependabot actions/setup-go — superseded
+ca7e87b7  M*  SKIP           go.mod/go.sum churn only
+fa510a60  M*  SKIP           runner+gitignore churn (reverts mandatory runner)
+# Upstreamed subnet/dual-stack chain (also skip-listed -> SKIP; see capi-1.12-parity.md)
+01e06d72  F3  SKIP           Custom subnet — native in upstream subnets pkg
+d8e22c72  F3  SKIP           Managed-cluster subnet — native upstream
+5dff97d6  F3  SKIP           k8scloud.Option subnet iface — obsolete upstream
+8a9fbde4  F3  SKIP           EnableFlowLogs nil-check — upstream ptr.Deref
+615e368e  F3  SKIP           StackType subnet — native upstream
+2e9689fc  F3  SKIP           dual-stack types — native upstream
+# Confirmed already-upstream (also skip-listed -> SKIP)
+0deeaee4  F3  SKIP           rm caBundle — upstream already
+6e5d77aa  F3  SKIP           wrap nodepool err — upstream already
+21f949b2  F3  SKIP           k8s 1.29+ template — upstream past 1.29
+# Upstream docs/CI noise (also skip-listed -> SKIP)
+4807642a  F3  SKIP           codespell.yml — upstream
+85f81b9f  F3  SKIP           lint.yml — upstream
+72b022e1  F3  SKIP           link-check.yml — upstream
+ad62434c  F3  SKIP           docs e2e guide — upstream
+d7fdb038  F3  SKIP           docs link fix — upstream
+cf4d2449  F3  SKIP           docs clusterclass — upstream
+85a7d941  F3  SKIP           docs restructure — upstream

--- a/.claude/memory/capi-upgrade/regwatch-risk.tsv
+++ b/.claude/memory/capi-upgrade/regwatch-risk.tsv
@@ -1,0 +1,10 @@
+# Regression-Watch risk ledger (Patch B durability) — "<sha> <L|M|H> [note]".
+# Reviewer-assigned risk survives re-plans (engine reads this instead of resetting to REVIEW).
+# UNSET/REVIEW and High BLOCK execute via --check-regwatch. Set by capi-plan-reviewer 2026-07-07.
+#
+# sha        risk  note
+e97ddf43     L     Spectro CICD — conflict only on Dockerfile/Makefile (build-var churn). No CAPI/GCP API surface; resolver 3-way merge is mechanical.
+eb9fc94c     L     Self-hosted runner — conflict only on .github/workflows/spectro-release.yaml. CI yaml, mechanical; downstream of e97ddf43.
+0c6fb0e0     M     Route-delete fix in cloud/services/compute/networks (F4 hotspot). Target restructured networks+added native subnets pkg; no CAPI-type crossing but resolver must confirm the fix still applies and is not already fixed upstream.
+38428b73     M     GCPMachineTemplate ref fix. Fork file api/v1beta1/gcpmachinetemplate_webhook.go; target RELOCATED webhook code to webhooks/. Structural relocation — re-apply the ref fix in the new location; confirm target has not already corrected the reference.
+e41bf6ae     L     F4 Instance Size / NodePoolVersion. CONTRACT-CROSSING: source uses MachinePool from cluster-api/exp/api/v1beta1 with Spec.Template.Spec.Version as *string (nil-checked, TrimPrefix). Target moved MachinePool to cluster-api/api/core/v1beta2 with Version as a non-pointer string ("" check). This is a semantic rewrite (pointer->value + type-namespace move), not a mechanical resolve — high behavior-loss risk. REQUIRES EXPLICIT HUMAN SIGN-OFF (blocks execute by design).

--- a/.claude/memory/capi-upgrade/resolve-commits.txt
+++ b/.claude/memory/capi-upgrade/resolve-commits.txt
@@ -1,0 +1,12 @@
+# Explicit PICK-RESOLVE commits — one short SHA per line; # = comment.
+# Human-approved force-picks of conflicting commits (per Patch D):
+# the engine no longer emits NEEDS-DECISION; at execute, each row is
+# handed to capi-conflict-resolver for a 3-way merge (fork intent vs
+# target code vs upstream evolution). Resolver may drop fork behavior
+# → adds a Regression Watch entry; unresolved → NEEDS-HUMAN + INCOMPLETE.
+
+# --- PR #282 Gate-1 human decision (round 2, replan): PICK-RESOLVE ---
+e97ddf43   # Spectro CICD integration — conflict on Dockerfile, Makefile (mechanical)
+0c6fb0e0   # Resolved route delete issue — conflict on cloud/services/compute/networks/{reconcile,service}.go
+38428b73   # PCP-268 GCPMachineTemplate ref fix — conflict on webhooks/gcpmachinetemplate_webhook.go
+eb9fc94c   # Self-hosted runner changes — conflict on .github/workflows/spectro-release.yaml (downstream of e97ddf43)

--- a/.claude/memory/capi-upgrade/skip-commits.txt
+++ b/.claude/memory/capi-upgrade/skip-commits.txt
@@ -1,0 +1,68 @@
+# Explicit commits to SKIP during reconcile/apply (one short SHA per line; # = comment).
+# Skipped BEFORE cherry-pick, so they never produce a conflict.
+# Rationale: routine spectro maintenance — package/Go/CVE bumps that upstream v1.12.x
+# already carries at equal-or-higher versions (confirmed by go.mod/go.sum conflicts).
+
+# --- dependabot / CI chore bumps (already in upstream) ---
+ef3e587d   # chore: bump actions/checkout 4.2.1->4.2.2
+b30a9407   # chore: bump actions/setup-go 5.0.2->5.1.0
+
+# --- Go toolchain / builder bumps (target is on newer Go) ---
+da80f8c6   # Update Go to v1.23.8
+beb5582e   # Update Go and Builder Golang versions to 1.24.12
+21359136   # PCP-6027 Update go version in spectro release yaml
+5b7e0a5c   # PCP-6734 Update go version for build
+
+# --- CVE / vuln package fixes (deps already higher upstream) ---
+5de82ade   # PCP-4129 CVE Fixes
+ce141d51   # PCP-6734 Fix go vulns
+3a44b400   # PCP-6891 updated go version & packages for vulnerabilities
+
+# --- human-approved 2026-06-30 (was borderline; user OK'd dropping both) ---
+d60388ac   # PCP-5293 controller-runtime -> v0.20.4. CAUTION: carries controller code
+           #   adaptation, not just a dep bump. Target v1.12.x already uses newer cr (v0.22.5),
+           #   so the adaptation is presumed upstream — DRIFT-DIFF to confirm before final apply.
+ca7e87b7   # Merge PR #273 PCP-6787 (go.mod/go.sum churn only)
+
+# --- decided 2026-06-30: SKIP. Reverts the mandatory self-hosted runner (eb9fc94c) back
+#     to ubuntu-latest, brings unwanted go.mod/go.sum churn; only unique content is a
+#     trivial ".gitignore vendor/" line. Not worth the entanglement. ---
+fa510a60   # chore: .gitignore + runner change (#265)
+
+# === Added 2026-06-30 (capi-1.12 cycle) ============================================
+
+# --- F4 subnetwork / dual-stack chain: UPSTREAMED in v1.12.0, human-approved skip ---
+#     Upstream v1.12.0 implements custom subnetwork creation natively in a dedicated
+#     cloud/services/compute/subnets/ package, and StackType/dual-stack in scope+types.
+#     Spectro placed this logic in cloud/services/compute/networks/ -> would conflict.
+#     Decision: adopt upstream's native impl, do NOT replay spectro's variant.
+#     FUNCTIONALITY-LOSS REVIEW: see .claude/memory/capi-upgrade/capi-1.12-parity.md (review before release).
+01e06d72   # Subnetwork implementation for Custom network creation
+d8e22c72   # Subnetwork support for managed cluster
+5dff97d6   # Fix k8scloud.Option subnetwork/routes interfaces
+8a9fbde4   # nil check for EnableFlowLogs in subnet
+615e368e   # StackType / dual-stack subnet (StackType now native upstream)
+2e9689fc   # Adding the ability to enable dual stacks (types.go; native upstream)
+
+# --- resolved TBD: confirmed already in upstream v1.12.0 -> skip ---
+0deeaee4   # rm caBundle: upstream webhook_in_*.yaml already has no caBundle placeholder
+6e5d77aa   # wrap nodepool update/delete err: upstream nodepools/reconcile.go already wraps
+21f949b2   # Support k8s 1.29+: template-only (5 lines); upstream templates long past 1.29
+
+# --- upstream noise (docs / CI yml / dependabot): not spectro-specific, skip ---
+4807642a   # Update codespell.yml
+85f81b9f   # Update lint.yml
+72b022e1   # Update link-check.yml
+ad62434c   # docs: add new e2e guide to book
+d7fdb038   # docs: fix broken link after book restructure
+cf4d2449   # docs: add clusterclass guide
+85a7d941   # docs: restructure book sections
+
+# --- CVE/go-vuln fixes SKIPed per PCP-5299 Gate-1 human decision on PR #282
+# --- (reviewer verdict: superseded upstream by CAPI v1.12.8 dep bump; re-scan on Code PR) ---
+a1a437e1   # PCP-6734 Fix go vulns — go.mod/go.sum conflict; superseded by CAPI v1.12.8
+a7a2398b   # PCP-6787 Fix CVEs — go.mod/go.sum conflict; superseded by CAPI v1.12.8
+330f68d7   # PCP-6891 updated go version & packages — workflow yaml conflict; superseded upstream
+
+# --- human Gate-1 decision (PR #282, 2026-07-07) ---
+e41bf6ae  # human: DROP/SKIP — NodePoolVersion (*string->string) rewrite NOT carried; accepted behavior change vs core/v1beta2 MachinePool


### PR DESCRIPTION
## CAPx upgrade workflow — per-repo memory + decision ledgers (CAPG)

**Workflow files only** (`.claude/memory/capi-upgrade/` — no code). Enables the Luma Protocol U engine (`spectro-capx-upgrade` plugin) on this fork.

- `capi-upgrade.conf` — CLOUD=gcp, CBT_FEATURE, VENDORCRD, BUILD_VARS keys
- decision ledgers — PCP-6871 reconcile decisions (reviewer-converged, human Gate-1 on [#282](https://github.com/spectrocloud-public/cluster-api-provider-gcp/pull/282); `e41bf6ae` NodePoolVersion rewrite deliberately dropped)
- `regwatch-risk.tsv` — durable Regression-Watch risk ledger
- `capi-1.12-parity.md` — subnet/dual-stack parity evidence for the SKIP-upstreamed chain

Note: replaces the old local `capx-tooling` branch, which mixed these files with code cherry-picks (those belong to the upgrade Code PR [#286](https://github.com/spectrocloud-public/cluster-api-provider-gcp/pull/286)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
